### PR TITLE
Fix two small issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 BuildResults
 xcuserdata
+.DS_Store
+

--- a/Sources/Extras/CoreMediaIO/DeviceAbstractionLayer/Devices/Sample/Assistant/Server/Device/CMIO_DPA_Sample_Server_VCamDevice.cpp
+++ b/Sources/Extras/CoreMediaIO/DeviceAbstractionLayer/Devices/Sample/Assistant/Server/Device/CMIO_DPA_Sample_Server_VCamDevice.cpp
@@ -14,6 +14,7 @@
 
 // Internal Includes
 #include "CMIO_DPA_Sample_Server_VCamInputStream.h"
+#include "CAHostTimeBase.h"
 
 namespace CMIO { namespace DPA { namespace Sample { namespace Server
 {
@@ -83,8 +84,8 @@ namespace CMIO { namespace DPA { namespace Sample { namespace Server
             fseek(vcamDevice->mSequenceFile, (vcamDevice->mFrameIndex % vcamDevice->mFrameCount) * vcamDevice->mFrameSize, SEEK_SET);
             fread(framebuffer, 1, vcamDevice->mFrameSize, vcamDevice->mSequenceFile);
             ++vcamDevice->mFrameIndex;
-
-            UInt64 vbiTime = vcamDevice->mInputStream->GetTimecode() * 1000000000.0;
+            // Hack because it seems that vcamDevice->mInputStream->GetTimecode() is always 0
+            UInt64 vbiTime = CAHostTimeBase::GetCurrentTimeInNanos();
             vcamDevice->mInputStream->FrameArrived(vcamDevice->mFrameSize, framebuffer, vbiTime);
         }
         

--- a/Sources/Extras/CoreMediaIO/DeviceAbstractionLayer/Devices/Sample/Assistant/com.apple.cmio.DPA.SampleVCam.plist
+++ b/Sources/Extras/CoreMediaIO/DeviceAbstractionLayer/Devices/Sample/Assistant/com.apple.cmio.DPA.SampleVCam.plist
@@ -6,7 +6,7 @@
 	<string>com.apple.cmio.DPA.SampleVCam</string>
 	<key>ProgramArguments</key>
 	<array>
-		<string>/Library/CoreMediaIO/Plug-Ins/DAL/Sample.plugin/Contents/Resources/SampleVCamAssistant</string>
+		<string>/Library/CoreMediaIO/Plug-Ins/DAL/SampleVCam.plugin/Contents/Resources/SampleVCamAssistant</string>
 	</array>
 	<key>MachServices</key>
 	<dict>


### PR DESCRIPTION
Solving two issues:
* `vcamDevice->mInputStream->GetTimecode()` was always 0 in SampleVCamAssistant. I'm not sure why this is. This prevented playback of the virtual camera in some devices (including QuickTime)
* `com.apple.cmio.DPA.SampleVCam.plist` was pointing to the `Sample.plugin` instead of `SampleVCam.plugin`

Happy to split these out into separate PRs if that'd be preferred; for now, I'll just collect all of my changes that make sense upstream here.